### PR TITLE
chore: bump validators, to dismiss CVE-2024-12224

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4"
 rocket-client-addr = "0.5"
 
 [dependencies.validators]
-version = "0.25"
+version = "0.26"
 default-features = false
 features = ["derive", "rocket", "base64_url", "regex"]
 


### PR DESCRIPTION
Blocked on https://github.com/magiclen/validators/pull/7 and assumes version 0.26, which may instead be 0.25.4.